### PR TITLE
fix: remove extra padding from banner in hero mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-card",
-  "version": "0.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/style-banner.scss
+++ b/src/style-banner.scss
@@ -153,6 +153,7 @@ img {
       align-items: unset;
       text-align: left;
       width: 50%;
+      padding-left: 0;
     }
 
     .contentWrapper {


### PR DESCRIPTION
# Alaska Airlines Pull Request

Fixes padding left


## Summary:
The hero and marquee variants are designed to be full width with a white background and thus shouldn't have padding left.  This changes fixes that so the text is flush to the left and aligned with other components on the page it is placed in.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability



## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
