### PR TITLE
fix: fix responsive banner

### DIFF
--- a/demo/banner-demo.md
+++ b/demo/banner-demo.md
@@ -392,7 +392,7 @@ The following example illustrates a `auro-banner` custom element with the `round
 
 <div class="exampleWrapper">
   <auro-banner roundedBorder alignLeft>
-  <img src="https://sitecore-prod-cd-westus2.azurewebsites.net/-/media/Images/common-assets/bank/2020/Visa-2020.png?la=en" alt="" slot="contentImage" />
+  <img src="https://sitecore-prod-cd-westcentralus.azurewebsites.net/-/media/Images/photos-infographics/credit-card/visa_signature" alt="" slot="contentImage" />
     <span slot="prefix">Prefix - Limited Time</span>
     <span slot="title">Title - Irure dolor.</span>
     <p slot="description">
@@ -417,7 +417,7 @@ The following example illustrates a `auro-banner` custom element with the `round
 
 ```html
 <auro-banner roundedBorder alignLeft>
-  <img src="https://sitecore-prod-cd-westus2.azurewebsites.net/-/media/Images/common-assets/bank/2020/Visa-2020.png?la=en" alt="" slot="contentImage" />
+  <img src="https://sitecore-prod-cd-westcentralus.azurewebsites.net/-/media/Images/photos-infographics/credit-card/visa_signature" alt="" slot="contentImage" />
   <span slot="prefix">Prefix - Limited Time</span>
   <span slot="title">Title - Irure dolor.</span>
   <p slot="description">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/auro-card",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/style-banner.scss
+++ b/src/style-banner.scss
@@ -211,6 +211,7 @@
 
     @include auro_breakpoint--sm {
       flex-basis: 70%;
+      flex-grow: 1;
     }
   }
 
@@ -223,26 +224,28 @@
   }
 
   .bodyWrapper {
-    padding: 1rem;
+    padding: var(--auro-size-md);
+    @include auro_breakpoint--md {
+      padding: var(--auro-size-lg);
+    }
+
+    @include auro_breakpoint--lg {
+      padding: var(--auro-size-xl);
+    }
     align-items: center;
 
     @include auro_breakpoint--sm {
       flex-direction: row;
-      padding: 1rem 2rem;
     }
   }
 
   .imageWrapper {
 
     @include auro_breakpoint--sm {
-      flex-basis: 435px;
+      flex-basis: 30%;
       display: flex;
       margin-right: 2rem;
       margin-bottom: 0;
-    }
-
-    @include auro_breakpoint--md {
-      flex-basis: 400px;
     }
   }
 }
@@ -254,7 +257,6 @@
   .bodyWrapper {
     align-items: flex-end;
     text-align: right;
-    width: 100%;
   }
 }
 
@@ -265,7 +267,6 @@
   .bodyWrapper {
     align-items: flex-start;
     text-align: left;
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

## Summary:
Fixes an issue when you set alignLeft or alignRight with a hero or maquee banner:
![image](https://user-images.githubusercontent.com/5118118/111691083-27385680-87eb-11eb-8c5c-bd8ab791835c.png)

Also continues off the last change to make the image on the roundedBorder flex-basis 30% and includes a larger svg in the demo to go with it.

![image](https://user-images.githubusercontent.com/5118118/111691345-72526980-87eb-11eb-80c5-0450449f658d.png)


## Type of change:

Please delete options that are not relevant.
- [x] Revision of an existing capability



## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
